### PR TITLE
3.0 breaking rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,52 +44,38 @@ export const bookAuthorResolver = (book, args, context) => {
 }
 ```
 
-## Filtered DataLoaders
+## One-to-Many DataLoaders
 The `register` and `get` methods are only appropriate for primary key loaders (or another key that
 identifies exactly one record). To fetch relations that return an array, a more complex pattern is required.
-This pattern also allows you to send optional filters for the array, so the methods are named
-`registerFiltered` and `getFiltered`.
 
-Consider the following GraphQL query:
-```graphql
-{ authors { books(genre: "mystery") { title } } }
-```
-Without dataloader-factory, the typical pattern for the authors.books dataloader looks like this:
-```javascript
-const booksByAuthorId = new DataLoader(async (authorIds) => {
-  const books = await db.query(
-    `SELECT * FROM books WHERE authorId IN (${authorIds.map(id => '?').join(',')})`
-  , authorIds)
-  const bookMap = lodash.groupBy(books, 'authorId')
-  return authorIds.map(id => bookMap[id] || [])
-})
-```
-But adding the `genre: "mystery"` filter is not obvious and can be very confusing to implement.
+The first of these patterns is the one-to-many pattern. Use it when your fetch function will return objects
+that can be mapped back to a single key value. For instance, a page always exists inside a single book, so the
+`pagesByBookId` dataloader might look like this:
 
-That's where this library really shines. Using dataloader-factory, the resolver would look like this
-(ignore the overly simplistic data model for genre):
 ```javascript
 import { DataLoaderFactory } from 'dataloader-factory'
-DataLoaderFactory.registerFiltered('booksByAuthorId', {
-  fetch: (authorIds, filters) => {
-    const query = `SELECT * FROM books WHERE authorId IN (${authorIds.map('?').join(',')})`
-    const params = [...authorIds]
-    if (filters.genre) {
-      query += ' AND genre=?'
-      params.push(filters.genre)
-    }
-    return db.query(query, params)
+DataLoaderFactory.registerOneToMany('pagesByBookId', {
+  fetch: async bookids => {
+    return db.query(`SELECT * FROM pages WHERE bookId IN (${bookids.map(id => '?').join(',')})`, bookids)
   },
-  extractKey: book => book.authorId
+  extractKey: page => page.bookId
 })
-export const authorBooksResolver = (author, args, context) => {
-  return context.dataLoaderFactory.getFiltered('booksByAuthorId', args).load(author.id)
+```
+The resolver might then look like this:
+```javascript
+export const bookPagesResolver = (book, args, context) => {
+  return context.dataLoaderFactory.getOneToMany('pagesByBookId', args).load(book.id)
 }
 ```
-Behind the scenes, what this does is generate a distinct DataLoader for each set of args used on that resolver. Since a graphql query is always finite, and each request gets a new factory, the number of possible DataLoaders generated is finite and manageable as well.
+Note that this is also useful for many-to-many relationships that have a named intermediary. For instance,
+the relationship between a book and a library might be represented as an `Acquisition` that links a book and a
+library and additionally lists a date the book was purchased.  In this case the dataloader for `book -> acquisition` is
+one-to-many, the dataloader for `library -> acquisition` is one-to-many, and for `book -> library` the developer has the
+option of chaining `book -> acquisition -> library` or creating a new many-to-many dataloader that uses a database join
+for efficiency (see the "Many-to-Many-Joined" section below).
 
 ### Options
-`registerFiltered` accepts the following inputs:
+`registerOneToMany` accepts the following inputs:
 ```javascript
 {
   // accept arbitrary foreign keys and arbitrary arguments and return results
@@ -126,6 +112,119 @@ Behind the scenes, what this does is generate a distinct DataLoader for each set
 }
 ```
 
+## Many-to-Many DataLoaders
+For DataLoaderFactory, Many-to-Many is split into two use-cases: one targeted at document-oriented databases like MongoDB (this section),
+another for relational databases like MySQL or Oracle (see the next section, "Many-to-Many-Joined").
+
+In document-oriented databases a typical pattern for a simple many-to-many relationship is to store an array of keys
+inside one of the documents. For instance, a book might be represented like this:
+```javascript
+{
+  id: 1,
+  title: 'Great American Novel',
+  genreIds: [1,3,8]
+}
+```
+The `Book.genres` resolver is trivial, you can use the primary key loader for `genres`. However, `Genre.books`
+requires a special treatment from DataLoaderFactory that asks you for `extractKeys` instead of `extractKey`
+(all other options are identical):
+```javascript
+import { DataLoaderFactory } from 'dataloader-factory'
+DataLoaderFactory.registerManyToMany('booksByGenreId', {
+  fetch: async genreIds => {
+    return db.collection('books').find({ genreIds }).toArray() // mongodb client syntax
+  },
+  extractKeys: book => book.genreIds
+})
+```
+and the resolver
+```javascript
+export const bookPagesResolver = (book, args, context) => {
+  return context.dataLoaderFactory.getManyToMany('booksByGenreId', args).load(book.id)
+}
+```
+Note that it is also possible to use a named intermediary in document-oriented databases. Depending on the database,
+you may still find the Many-to-Many-Joined pattern useful in those cases.
+
+## Many-to-Many-Joined DataLoaders
+It is possible to handle many to many relationships with the oneToMany pattern, like this:
+```javascript
+import { DataLoaderFactory } from 'dataloader-factory'
+DataLoaderFactory.registerOneToMany('booksByGenreId', {
+  fetch: async genreIds => {
+    const books = await db.get(`
+      SELECT b.*, g.id as genreId
+      FROM books b
+      INNER JOIN books_genres bg ON b.id = bg.book_id
+      INNER JOIN genres g ON g.id = bg.genre_id
+      WHERE g.id IN (${genreIds.map(id => '?').join(',')})`)
+    return books
+  },
+  extractKey: book => book.genreId
+})
+```
+This will work but it means the `Book` object being passed to the rest of your code has a `genreId` property that doesn't
+really belong there. This is especially annoying when using Typescript as you need to create a new interface like `BookWithGenreId`
+to represent this not-quite-a-book object.
+
+Luckily DataLoaderFactory provides a cleaner pattern with `registerManyJoined` and `getManyJoined`:
+```javascript
+import { DataLoaderFactory } from 'dataloader-factory'
+DataLoaderFactory.registerManyJoined('booksByGenreId', {
+  fetch: async genreIds => {
+    const books = await db.get(`
+      SELECT b.*, g.id as genreId
+      FROM books b
+      INNER JOIN books_genres bg ON b.id = bg.book_id
+      INNER JOIN genres g ON g.id = bg.genre_id
+      WHERE g.id IN (${genreIds.map(id => '?').join(',')})`)
+    return books.map(row => ({ key: row.genreId, value: new Book(row) }))
+  }
+})
+```
+You no longer provide an `extractKey` function because you return it with each row. DataLoaderFactory
+will use the key you provide to put the data back together and then discard it, returning only the pristine
+`Book` from the `value` field back to the `.load()` call in your resolver.
+
+## Parameter-based filtering
+Consider the following GraphQL query:
+```graphql
+{ authors { books(genre: "mystery") { title } } }
+```
+Without dataloader-factory, the typical pattern for the authors.books dataloader looks like this:
+```javascript
+const booksByAuthorId = new DataLoader(async (authorIds) => {
+  const books = await db.query(
+    `SELECT * FROM books WHERE authorId IN (${authorIds.map(id => '?').join(',')})`
+  , authorIds)
+  const bookMap = lodash.groupBy(books, 'authorId')
+  return authorIds.map(id => bookMap[id] || [])
+})
+```
+But adding the `genre: "mystery"` filter is not obvious and can be very confusing to implement.
+
+That's where this library really shines. Using dataloader-factory, the resolver would look like this
+(ignore the overly simplistic data model):
+```javascript
+import { DataLoaderFactory } from 'dataloader-factory'
+DataLoaderFactory.registerOneToMany('booksByAuthorId', {
+  fetch: (authorIds, filters) => {
+    const query = `SELECT * FROM books WHERE authorId IN (${authorIds.map('?').join(',')})`
+    const params = [...authorIds]
+    if (filters.genre) {
+      query += ' AND genre=?'
+      params.push(filters.genre)
+    }
+    return db.query(query, params)
+  },
+  extractKey: book => book.authorId
+})
+export const authorBooksResolver = (author, args, context) => {
+  return context.dataLoaderFactory.getOneToMany('booksByAuthorId', args).load(author.id)
+}
+```
+Behind the scenes, what this does is generate a distinct DataLoader for each set of args used on that resolver. Since a graphql query is always finite, and each request gets a new factory, the number of possible DataLoaders generated is finite and manageable as well.
+
 ## Advanced Usage Example
 Many GraphQL data types will have more than one other type referencing them. In those
 cases, it will probably be useful to create a single function for constructing and
@@ -150,13 +249,13 @@ const executeBookQuery = filters => {
   const wherestr = where.length && `WHERE (${where.join(') AND (')})`
   return db.query(`SELECT * FROM books ${wherestr}`, params)
 }
-DataLoaderFactory.registerFiltered('booksByAuthorId', {
+DataLoaderFactory.registerOneToMany('booksByAuthorId', {
   fetch: (authorIds, filters) {
     return executeBookQuery({ ...filters, authorIds })
   },
   extractKey: item => item.authorId
 })
-DataLoaderFactory.registerFiltered('booksByGenre', {
+DataLoaderFactory.registerOneToMany('booksByGenre', {
   fetch: (genres, filters) => {
     return executeBookQuery({ ...filters, genres })
   },
@@ -180,7 +279,7 @@ will help us put the fetched dataset back together properly.
 Please note that this makes the batched load an O(n^2) operation so `extractKey` is
 preferred whenever possible and a smaller `maxBatchSize` would be wise.
 ```javascript
-DataLoaderFactory.registerFiltered('booksAfterYear', {
+DataLoaderFactory.registerOneToMany('booksAfterYear', {
   fetch: (years, filters) => {
     const ors = years.map(parseInt).map(year => `published > DATE('${year}0101')`)
     return db.query(`SELECT * FROM books WHERE ${ors.join(') OR (')}`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ option of chaining `book -> acquisition -> library` or creating a new many-to-ma
 for efficiency (see the "Many-to-Many-Joined" section below).
 
 ### Options
-`registerOneToMany` accepts the following inputs:
+`registerOneToMany` accepts the following inputs. All of the *-to-many patterns accept the same options, except as
+noted in their section of the documentation.
 ```javascript
 {
   // accept arbitrary foreign keys and arbitrary arguments and return results
@@ -98,11 +99,6 @@ for efficiency (see the "Many-to-Many-Joined" section below).
 
   // cacheKeyFn to be passed to each DataLoader
   cacheKeyFn: key => stringify(key)
-
-  // Usually registerFiltered is for relations that return arrays, but in rare cases
-  // it may be useful on a one-to-one relation. If this is set to true, each call to
-  // DataLoader.load() will return an object instead of an array of objects
-  returnOne: false
 
   // set idLoaderKey to the registered name of an ID Loader to automatically
   // prime it with any results gathered
@@ -132,15 +128,15 @@ requires a special treatment from DataLoaderFactory that asks you for `extractKe
 import { DataLoaderFactory } from 'dataloader-factory'
 DataLoaderFactory.registerManyToMany('booksByGenreId', {
   fetch: async genreIds => {
-    return db.collection('books').find({ genreIds }).toArray() // mongodb client syntax
+    return db.collection('books').find({ genreIds: { $in: genreIds } }).toArray() // mongodb client syntax
   },
   extractKeys: book => book.genreIds
 })
 ```
 and the resolver
 ```javascript
-export const bookPagesResolver = (book, args, context) => {
-  return context.dataLoaderFactory.getManyToMany('booksByGenreId', args).load(book.id)
+export const genreBooksResolver = (genre, args, context) => {
+  return context.dataLoaderFactory.getManyToMany('booksByGenreId').load(genre.id)
 }
 ```
 Note that it is also possible to use a named intermediary in document-oriented databases. Depending on the database,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dataloader-factory",
-  "version": "1.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@types/js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-0CFu/g4mDSNkodVwWijdlr8jH7RoplRWNgovjFLEZeT+QEbbZXjBmCe3HwaWheAlCbHwomTwzZoSedeOycABug==",
       "dev": true
     },
     "@types/mocha": {
@@ -23,9 +23,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz",
-      "integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==",
+      "version": "12.12.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+      "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
       "dev": true
     },
     "ansi-colors": {
@@ -50,9 +50,9 @@
       }
     },
     "arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -207,9 +207,9 @@
       "dev": true
     },
     "dataloader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
     "debug": {
       "version": "3.2.6",
@@ -683,9 +683,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -753,22 +753,22 @@
       }
     },
     "ts-node": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
-      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
+      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
+        "yn": "3.1.1"
       },
       "dependencies": {
         "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
       }
@@ -780,9 +780,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataloader-factory",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "DataLoader classes to make it easier to write complex graphql resolvers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataloader-factory",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "DataLoader classes to make it easier to write complex graphql resolvers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataloader-factory",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "DataLoader classes to make it easier to write complex graphql resolvers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,14 +22,14 @@
   "homepage": "https://github.com/txstate-etc/dataloader-factory#readme",
   "devDependencies": {
     "@types/chai": "4.1.3",
-    "@types/js-yaml": "^3.12.1",
+    "@types/js-yaml": "^3.12.2",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.12.3",
+    "@types/node": "^12.12.26",
     "chai": "^4.2.0",
     "js-yaml": "^3.13.1",
     "mocha": "^6.2.2",
-    "ts-node": "^8.4.1",
-    "typescript": "^3.6.4"
+    "ts-node": "^8.6.2",
+    "typescript": "^3.7.5"
   },
   "dependencies": {
     "dataloader": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataloader-factory",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "DataLoader classes to make it easier to write complex graphql resolvers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,21 +10,21 @@ interface BaseManyLoaderConfig<KeyType, ReturnType> {
 }
 
 interface OneToManyLoaderConfig<KeyType, ReturnType, FilterType, ContextType> extends BaseManyLoaderConfig<KeyType, ReturnType> {
-  fetch: (keys: KeyType[], filters?:FilterType, context?:ContextType) => Promise<ReturnType[]>
+  fetch: (keys: KeyType[], filters:FilterType, context:ContextType) => Promise<ReturnType[]>
   extractKey?: (item:ReturnType) => KeyType
 }
 
 interface ManyJoinedLoaderConfig<KeyType, ReturnType, FilterType, ContextType> extends BaseManyLoaderConfig<KeyType, ReturnType> {
-  fetch: (keys: KeyType[], filters?:FilterType, context?:ContextType) => Promise<{ key: KeyType, value: ReturnType }[]>
+  fetch: (keys: KeyType[], filters:FilterType, context:ContextType) => Promise<{ key: KeyType, value: ReturnType }[]>
 }
 
 interface ManyToManyLoaderConfig<KeyType, ReturnType, FilterType, ContextType> extends BaseManyLoaderConfig<KeyType, ReturnType> {
-  fetch: (keys: KeyType[], filters?:FilterType, context?:ContextType) => Promise<ReturnType[]>
+  fetch: (keys: KeyType[], filters:FilterType, context:ContextType) => Promise<ReturnType[]>
   extractKeys?: (item:ReturnType) => KeyType[]
 }
 
 interface LoaderConfig<KeyType, ReturnType, ContextType> {
-  fetch: (ids:KeyType[], context?: ContextType) => Promise<ReturnType[]>
+  fetch: (ids:KeyType[], context: ContextType) => Promise<ReturnType[]>
   extractId?: (item:ReturnType) => KeyType
   options?: DataLoader.Options<KeyType,ReturnType,string>
 }
@@ -43,9 +43,9 @@ export class DataLoaderFactory<ContextType> {
   private static filteredRegistry:{ [keys:string]: OneToManyLoaderConfig<any,any,any,any>|ManyToManyLoaderConfig<any,any,any,any>|ManyJoinedLoaderConfig<any,any,any,any> } = {}
   private loaders: { [keys:string]: DataLoader<any,any> }
   private filteredLoaders: { [keys:string]: { [keys:string]: FilteredStorageObject<any,any> }}
-  private context?: ContextType
+  private context: ContextType
 
-  constructor (context?: ContextType) {
+  constructor (context: ContextType = {} as ContextType) {
     this.loaders = {}
     this.filteredLoaders = {}
     this.context = context

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ export class DataLoaderFactory<ContextType> {
   }
 
   static registerManyJoined<KeyType = any, ReturnType = any, FilterType = any, ContextType = any> (key: string, loader: ManyJoinedLoaderConfig<KeyType, ReturnType, FilterType, ContextType>) {
+    (loader as any).joined = true // to help generateloader tell the difference later
     DataLoaderFactory.filteredRegistry[key] = loader
   }
 
@@ -135,10 +136,11 @@ export class DataLoaderFactory<ContextType> {
         dedupekeys[stringkeys[i]] = keys[i]
       }
       const items = await loaderConfig.fetch(Object.values(dedupekeys), filters, this.context)
-      if ('matchKey' in loaderConfig) {
-        this.prime(loaderConfig, items as ReturnType[])
-      } else {
+      if ((loaderConfig as any).joined) {
+        // private option in loaderConfig tells me the return type is the joined type
         this.prime(loaderConfig, (items as { key: KeyType, value: ReturnType }[]).map(item => item.value))
+      } else {
+        this.prime(loaderConfig, items as ReturnType[])
       }
 
       const grouped: { [keys:string]: ReturnType[]} = {}

--- a/test/index.ts
+++ b/test/index.ts
@@ -27,7 +27,6 @@ DataLoaderFactory.registerOneToMany(BOOKS_BY_AUTHOR_ID_MATCHKEY, {
   matchKey: (key, item) => item.authorId === key
 })
 
-
 let byIdCount = 0
 const BOOKS_BY_ID = 'books'
 DataLoaderFactory.register(BOOKS_BY_ID, {
@@ -122,7 +121,7 @@ describe('bookloader', () => {
     expect(byAuthorIdCount).to.equal(2)
   })
   it('should have cached authorId fetches', async () => {
-    const cache = dataLoaderFactory.getFilteredcache(BOOKS_BY_AUTHOR_ID, { genre: 'mystery' })
+    const cache = dataLoaderFactory.getFilteredCache(BOOKS_BY_AUTHOR_ID, { genre: 'mystery' })
     expect(cache).to.have.length(6)
   })
   it('should load books with the ID dataloader', async () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -58,7 +58,8 @@ DataLoaderFactory.registerManyToMany(BOOKS_BY_GENRE, {
     const books = allbooks.filter(book => book.genres.some((genre:string) => genres.includes(genre)))
     return books
   },
-  extractKeys: book => book.genres
+  extractKeys: book => book.genres,
+  idLoaderKey: BOOKS_BY_ID
 })
 const BOOKS_BY_GENRE_MATCHKEY = 'booksByGenreMatchKey'
 DataLoaderFactory.registerManyToMany(BOOKS_BY_GENRE_MATCHKEY, {
@@ -77,7 +78,8 @@ DataLoaderFactory.registerManyJoined(BOOKS_BY_GENRE_JOINED, {
     const books = allbooks.filter(book => book.genres.some((genre:string) => genres.includes(genre)))
     // using [].concat because vscode/typescript was having fits about using .flat()
     return [].concat(...books.map(book => book.genres.map((g:any) => ({ key: g, value: book }))))
-  }
+  },
+  idLoaderKey: BOOKS_BY_ID
 })
 const BOOKS_BY_GENRE_JOINED_MATCHKEY = 'booksByGenreJoinedMatchKey'
 DataLoaderFactory.registerManyJoined(BOOKS_BY_GENRE_JOINED_MATCHKEY, {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
+    "lib": ["ES2019", "ESNEXT.Array"],
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
The major change here is removing the `registerFiltered` and `getFiltered` methods and replacing them with three new ones, `registerOneToMany`, `registerManyToMany`, and `registerManyJoined`.  `registerOneToMany` will cover most existing use cases of `registerFiltered` so the transition shouldn't be too difficult. It's also all strongly typed so it should be difficult to leave something in a broken state.

The README has been fully updated so refer to it for details.

Feedback welcome if anyone has a good idea on how to bring down the mental load on consumers.